### PR TITLE
fix: unhandled situation for whale pools

### DIFF
--- a/src/Infrastructure/Consumers/Terra/PylonGatewayPoolTransactionConsumer.cs
+++ b/src/Infrastructure/Consumers/Terra/PylonGatewayPoolTransactionConsumer.cs
@@ -156,7 +156,7 @@ public class PylonGatewayPoolTransactionConsumer : IConsumer<PylonGatewayPoolTra
 
                 var amount = new TerraAmount(
                     claimAmountStr.Value,
-                    TerraDenominators.AssetTokenAddressToDenominator[denominatorAddrStr.Value]
+                    TerraDenominators.TryGetDenominator(denominatorAddrStr.Value)
                 );
 
                 var data = new TerraPylonPoolEntity

--- a/src/Infrastructure/Consumers/Terra/PylonGatewayPoolTransactionConsumer.cs
+++ b/src/Infrastructure/Consumers/Terra/PylonGatewayPoolTransactionConsumer.cs
@@ -175,7 +175,7 @@ public class PylonGatewayPoolTransactionConsumer : IConsumer<PylonGatewayPoolTra
                 continue;
             }
 
-            _logger.LogError("Pylon Pool fetcher: unknown situation for tx: {TxHash}.... ", terraTx.TransactionHash);
+            _logger.LogWarning("Pylon Pool fetcher: unknown situation for tx: {TxHash}.... ", terraTx.TransactionHash);
         }
 
         return results;

--- a/src/TerraDotnet/TerraDenominators.cs
+++ b/src/TerraDotnet/TerraDenominators.cs
@@ -49,6 +49,7 @@ public static class TerraDenominators
         { TerraTokenContracts.LUNAX, Luna},
         { TerraTokenContracts.KUJI, Kuji},
         { TerraTokenContracts.ASTRO, Astro},
+        { TerraTokenContracts.WHALE, Whale},
     };
 
     /// <summary>


### PR DESCRIPTION
This error started popping in on New Relic:

```
System.Collections.Generic.KeyNotFoundException: The given key 'terra1php5m8a6qd68z02t3zpw4jv2pj4vgw4wz0t8mz' was not present in the dictionary.
   at Pylonboard.Infrastructure.Consumers.Terra.PylonGatewayPoolTransactionConsumer.ParseTransaction(TerraPylonPoolFriendlyName poolFriendlyName, String poolContractAddr, TerraTxWrapper terraTx)
   at Pylonboard.Infrastructure.Consumers.Terra.PylonGatewayPoolTransactionConsumer.Consume(ConsumeContext`1 context) in /Infrastructure/Consumers/Terra/PylonGatewayPoolTransactionConsumer.cs:line 55
   at MassTransit.Scoping.ScopeConsumerFactory`1.Send[TMessage](ConsumeContext`1 context, IPipe`1 next)
   at MassTransit.Scoping.ScopeConsumerFactory`1.Send[TMessage](ConsumeContext`1 context, IPipe`1 next)
   at MassTransit.Pipeline.Filters.ConsumerMessageFilter`2.GreenPipes.IFilter<MassTransit.ConsumeContext<TMessage>>.Send(ConsumeContext`1 context, IPipe`1 next)
   at MassTransit.Pipeline.Filters.ConsumerMessageFilter`2.GreenPipes.IFilter<MassTransit.ConsumeContext<TMessage>>.Send(ConsumeContext`1 context, IPipe`1 next)
   at GreenPipes.Filters.TeeFilter`1.<>c__DisplayClass5_0.<<Send>g__SendAsync|1>d.MoveNext()
--- End of stack trace from previous location ---
   at GreenPipes.Filters.OutputPipeFilter`2.SendToOutput(IPipe`1 next, TOutput pipeContext)
   at GreenPipes.Filters.OutputPipeFilter`2.SendToOutput(IPipe`1 next, TOutput pipeContext)
   at MassTransit.Pipeline.Filters.DeserializeFilter.Send(ReceiveContext context, IPipe`1 next)
   at GreenPipes.Filters.RescueFilter`2.GreenPipes.IFilter<TContext>.Send(TContext context, IPipe`1 next)
```

Which this PR should fix.