### PR TITLE
chore: add migration to increase hypertable chunk sizes

### DIFF
--- a/src/Infrastructure/DAL/Migrations/Migration_20220223_103600_IncreaseChunkSizes.cs
+++ b/src/Infrastructure/DAL/Migrations/Migration_20220223_103600_IncreaseChunkSizes.cs
@@ -1,0 +1,46 @@
+using System;
+using RapidCore.Migration;
+using RapidCore.PostgreSql.Migration;
+using ServiceStack.OrmLite;
+using ServiceStack.OrmLite.Dapper;
+
+namespace Pylonboard.ServiceHost.DAL.Migrations;
+
+public class Migration_20220223_103600_IncreaseChunkSizes : MigrationBase
+{
+    protected override void ConfigureUpgrade(IMigrationBuilder builder)
+    {
+        var ctx = ContextAs<PostgreSqlMigrationContext>();
+        var connection = ctx.ConnectionProvider.Default();
+
+        builder.Step("increase mine staking chunk size", () =>
+        {
+            connection.Execute(@"
+SELECT set_chunk_time_interval('terra_mine_staking_entity', INTERVAL '14 days');
+");
+        });
+        builder.Step("increase raw tx chunk size", () =>
+        {
+            connection.Execute(@"
+SELECT set_chunk_time_interval('terra_raw_transaction_entity', INTERVAL '7 days');
+");
+        });
+        builder.Step("increase pylon pool chunk size", () =>
+        {
+            connection.Execute(@"
+SELECT set_chunk_time_interval('terra_pylon_pool_entity', INTERVAL '30 days');
+");
+        });
+        builder.Step("increase liquidity pool chunk size", () =>
+        {
+            connection.Execute(@"
+SELECT set_chunk_time_interval('terra_liquidity_pool_entity', INTERVAL '90 days');
+");
+        });
+    }
+
+    protected override void ConfigureDowngrade(IMigrationBuilder builder)
+    {
+        throw new System.NotImplementedException();
+    }
+}


### PR DESCRIPTION
This PR will increase chunk sizes to avoid transactions grabbing too many locks when operating on the data and to increase overall Timescale performance.

For our 3 primary tables the chunk sizes are as such:

- mine staking largest chunk 20mb others around 12 to 15mb
- pylon pools  largest 1480 kB, other around 1000 Kb
- raw tx: largest chunk 53 mb, others around 20MB
- liquidity pool (trades): largest chunk 1120 kb, others around 700 kb

 

Our current production DB has 4gb of memory , so we can chunk to fit this into 1gb of memory
Current chunks:
- mine staking: 1 day
- raw tx: 1 day
- pylon pool: 1 day
- LP: 14 days

Mine staking seems reasonable at 14 days as this lands at worst case 280 mb
raw tx at 7 days too as worst case is 413 mb
pylon pools at 30 days has worst case 42 mb
LP at 90 days for now, as the data is currently sparse but as more LP trades are added the chunks will increase.

This only fixes it for new data flowing in. We'll have to temporarily stop the background worker from ingesting more data, dump all table data, truncate and reimport to get everything "re-chunked" 