### PR TITLE
PB-37: continued rewrite to mt consumers

### DIFF
--- a/src/Infrastructure/Consumers/Terra/MineStakingTransactionConsumer.cs
+++ b/src/Infrastructure/Consumers/Terra/MineStakingTransactionConsumer.cs
@@ -1,0 +1,191 @@
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Pylonboard.Kernel.Contracts.Terra;
+using Pylonboard.Kernel.DAL.Entities.Terra;
+using Pylonboard.Kernel.IdGeneration;
+using ServiceStack;
+using ServiceStack.Data;
+using ServiceStack.OrmLite;
+using TerraDotnet;
+using TerraDotnet.Extensions;
+using TerraDotnet.TerraFcd;
+using TerraDotnet.TerraFcd.Messages;
+using TerraDotnet.TerraFcd.Messages.Wasm;
+
+namespace Pylonboard.Infrastructure.Consumers.Terra;
+
+public class MineStakingTransactionConsumer : IConsumer<MineStakingTransactionMessage>
+{
+    private readonly ILogger<MineStakingTransactionConsumer> _logger;
+    private readonly IDbConnectionFactory _dbFactory;
+    private readonly IdGenerator _idGenerator;
+
+    public MineStakingTransactionConsumer(
+        ILogger<MineStakingTransactionConsumer> logger,
+        IDbConnectionFactory dbFactory,
+        IdGenerator idGenerator
+    )
+    {
+        _logger = logger;
+        _dbFactory = dbFactory;
+        _idGenerator = idGenerator;
+    }
+
+    public async Task Consume(ConsumeContext<MineStakingTransactionMessage> context)
+    {
+        using var db = _dbFactory.OpenDbConnection();
+        using var tx = db.OpenTransaction();
+        var terraTxId = context.Message.TransactionId;
+        _logger.LogInformation("Processing MINE gov transaction with id: {TxId}", terraTxId);
+        
+        var terraDbTx = await db.SingleByIdAsync<TerraRawTransactionEntity>(terraTxId);
+
+        var exists = await db.SingleAsync<long?>(db.From<TerraMineStakingEntity>()
+            .Where(q => q.TransactionId == terraTxId)
+            .Take(1)
+            .Select(e =>
+                new
+                {
+                    e.Id
+                }));
+        if (exists.HasValue)
+        {
+            _logger.LogDebug("Mine staking data for transaction id {TxId} already exists", exists);
+            tx.Rollback();
+            return;
+        }
+
+        var terraTx = terraDbTx.RawTx.ToObject<TerraTxWrapper>();
+        var msg = TerraTransactionValueFactory.GetIt(terraTx!);
+        var cancellationToken = context.CancellationToken;
+
+        var datum = ProcessTransaction(terraTx!, msg);
+        foreach (var data in datum)
+        {
+            await db.InsertAsync(data, token: cancellationToken);
+        }
+
+        tx.Commit();
+    }
+
+    /// <summary>
+    /// Process a single Terra transaction from the blockchain
+    /// </summary>
+    /// <param name="tx"></param>
+    /// <param name="msg"></param>
+    /// <returns>A boolean as to whether transaction enumeration should be STOPPED</returns>
+    public List<TerraMineStakingEntity> ProcessTransaction(
+        TerraTxWrapper tx,
+        CoreStdTx msg
+    )
+    {
+        var results = new List<TerraMineStakingEntity>();
+        foreach (var properMsg in msg.Messages.Select(innerMsg => innerMsg as WasmMsgExecuteContract))
+        {
+            if (properMsg == default)
+            {
+                _logger.LogWarning(
+                    "Transaction with id {Id} did not have a message of type {Type}",
+                    tx.Id,
+                    typeof(WasmMsgExecuteContract)
+                );
+                continue;
+            }
+
+            var amount = 0m;
+            if (properMsg.Value.ExecuteMessage?.CastVote != null || properMsg.Value.ExecuteMessage?.EndPoll != null)
+            {
+                _logger.LogDebug("Cast vote or end poll, ignoring");
+                continue;
+            }
+
+            if (properMsg.Value.ExecuteMessage?.Mint != null)
+            {
+                _logger.LogDebug("SPEC mint, ignoring");
+                continue;
+            }
+
+            if (properMsg.Value.ExecuteMessage?.Sweep != null || properMsg.Value.ExecuteMessage?.Earn != null)
+            {
+                _logger.LogDebug("Pylon buy-back sweep, handled later");
+                continue;
+            }
+
+            if (properMsg.Value.ExecuteMessage?.UpdateConfig != null)
+            {
+                _logger.LogDebug("Contract config update, ignore");
+                continue;
+            }
+
+            if (properMsg.Value.ExecuteMessage?.Transfer != null)
+            {
+                _logger.LogDebug("Contract COL-4 transfer, ignore");
+                continue;
+            }
+
+            if (properMsg.Value.ExecuteMessage?.Send != null)
+            {
+                if (!properMsg.Value.ExecuteMessage.Send.Contract.EqualsIgnoreCase(
+                        TerraStakingContracts.MINE_STAKING_CONTRACT))
+                {
+                    _logger.LogDebug("Send to contract that is not MINE governance, skipping ");
+                    continue;
+                }
+
+
+                amount = Convert.ToDecimal(properMsg.Value.ExecuteMessage.Send.Amount) / 1_000_000m;
+            }
+            // SPEC farm does funky stuff
+            else if (properMsg.Value.ExecuteMessage?.Withdraw != null)
+            {
+                _logger.LogDebug("Spec farm withdraw, skip");
+                continue;
+            }
+            // SPEC compounding provides tokens for the MINE governance contract
+            else if (properMsg.Value.ExecuteMessage.Compound != null)
+            {
+                _logger.LogDebug("Spec farm compound, skip");
+                continue;
+            }
+            else if (properMsg.Value.ExecuteMessage.Airdrop?.Claim != null)
+            {
+                _logger.LogDebug("Airdrop claim, skipping");
+                continue;
+            }
+            else if (properMsg.Value.ExecuteMessage.WithdrawVotingTokens != null)
+            {
+                amount = -1 *
+                         (Convert.ToDecimal(properMsg.Value.ExecuteMessage.WithdrawVotingTokens
+                             .Amount) / 1_000_000m);
+            }
+            else if (properMsg.Value.ExecuteMessage.Staking?.Unstake != null)
+            {
+                amount = -1 * properMsg.Value.ExecuteMessage.Staking.Unstake.Amount.ToInt64() / 1_000_000m;
+            }
+
+            else
+            {
+                _logger.LogWarning(
+                    "Transaction w. id {Id} and hash {TxHash} does not have send nor withdraw amount",
+                    tx.Id,
+                    tx.TransactionHash
+                );
+                continue;
+            }
+
+            var data = new TerraMineStakingEntity
+            {
+                Id = _idGenerator.Snowflake(),
+                TransactionId = tx.Id,
+                CreatedAt = tx.CreatedAt.UtcDateTime,
+                Sender = properMsg.Value.Sender,
+                Amount = amount,
+                TxHash = tx.TransactionHash,
+                IsBuyBack = false,
+            };
+            results.Add(data);
+        }
+
+        return results;
+    }
+}

--- a/src/Infrastructure/Hosting/TerraDataFetchers/MineStakingDataFetcher.cs
+++ b/src/Infrastructure/Hosting/TerraDataFetchers/MineStakingDataFetcher.cs
@@ -1,7 +1,9 @@
 using System.Data;
 using System.Text.Json;
+using MassTransit;
 using Microsoft.Extensions.Logging;
 using NewRelic.Api.Agent;
+using Pylonboard.Kernel.Contracts.Terra;
 using Pylonboard.Kernel.DAL.Entities.Terra;
 using Pylonboard.Kernel.IdGeneration;
 using ServiceStack;
@@ -18,20 +20,20 @@ public class MineStakingDataFetcher
 {
     private readonly ILogger<MineStakingDataFetcher> _logger;
     private readonly TerraTransactionEnumerator _transactionEnumerator;
-    private readonly IdGenerator _idGenerator;
     private readonly IDbConnectionFactory _dbFactory;
+    private readonly IBus _bus;
 
     public MineStakingDataFetcher(
         ILogger<MineStakingDataFetcher> logger,
         TerraTransactionEnumerator transactionEnumerator,
-        IdGenerator idGenerator,
-        IDbConnectionFactory dbFactory
+        IDbConnectionFactory dbFactory,
+        IBus bus
     )
     {
         _logger = logger;
         _transactionEnumerator = transactionEnumerator;
-        _idGenerator = idGenerator;
         _dbFactory = dbFactory;
+        _bus = bus;
     }
 
     [Trace]
@@ -51,204 +53,36 @@ public class MineStakingDataFetcher
                            TerraStakingContracts.MINE_STAKING_CONTRACT,
                            stoppingToken))
         {
-            if (await ProcessSingleTransactionAsync(tx, msg, latestRow, db, fullResync, stoppingToken))
-            {
-                break;
-            }
-        }
-
-        _logger.LogInformation("Done inserting transactions");
-    }
-
-    /// <summary>
-    /// Process a single Terra transaction from the blockchain
-    /// </summary>
-    /// <param name="tx"></param>
-    /// <param name="msg"></param>
-    /// <param name="latestRow"></param>
-    /// <param name="db"></param>
-    /// <param name="fullResync"></param>
-    /// <param name="stoppingToken"></param>
-    /// <returns>A boolean as to whether transaction enumeration should be STOPPED</returns>
-    public async Task<bool> ProcessSingleTransactionAsync(TerraTxWrapper tx,
-        CoreStdTx msg,
-        TerraMineStakingEntity? latestRow,
-        IDbConnection db,
-        bool fullResync,
-        CancellationToken stoppingToken
-    )
-    {
-        if (fullResync)
-        {
-            var exists = await db.SingleAsync(
-                db.From<TerraMineStakingEntity>()
-                    .Where(q => q.TransactionId == tx.Id && q.CreatedAt == tx.CreatedAt)
-                    .Take(1),
-                token: stoppingToken
-            );
-            if (exists != default)
+            // for delta-syncs we check whether the row already exists and then back off
+            // for full syncs the consumer has logic to dedupe existing transactions so we wish to pump them all though
+            if (!fullResync && tx.Id == latestRow?.TransactionId)
             {
                 _logger.LogInformation(
-                    "Transaction with id {TxId} and hash {TxHash} already exists, skipping during full resync",
-                    tx.Id, tx.TransactionHash);
-                return false;
-            }
-        }
-        else if (tx.Id == latestRow?.TransactionId)
-        {
-            _logger.LogInformation("Transaction with id {TxId} and hash {TxHash} already exists, aborting", tx.Id,
-                tx.TransactionHash);
-            return true;
-        }
-
-        using var dbTx = db.BeginTransaction();
-        await dbTx.Connection.SaveAsync(obj: new TerraRawTransactionEntity
-            {
-                Id = tx.Id,
-                CreatedAt = tx.CreatedAt,
-                TxHash = tx.TransactionHash,
-                RawTx = JsonSerializer.Serialize(tx),
-            },
-            token: stoppingToken
-        );
-
-        foreach (var properMsg in msg.Messages.Select(innerMsg => innerMsg as WasmMsgExecuteContract))
-        {
-            if (properMsg == default)
-            {
-                _logger.LogWarning("Transaction with id {Id} did not have a message of type {Type}", tx.Id,
-                    typeof(WasmMsgExecuteContract));
-                continue;
-            }
-
-            var amount = 0m;
-            if (properMsg.Value.ExecuteMessage.CastVote != null || properMsg.Value.ExecuteMessage.EndPoll != null)
-            {
-                _logger.LogDebug("Cast vote or end poll, ignoring");
-                continue;
-            }
-
-            if (properMsg.Value.ExecuteMessage.Mint != null)
-            {
-                _logger.LogDebug("SPEC mint, ignoring");
-                continue;
-            }
-
-            if (properMsg.Value.ExecuteMessage.Sweep != null || properMsg.Value.ExecuteMessage.Earn != null)
-            {
-                _logger.LogDebug("Pylon buy-back sweep, handled later");
-                continue;
-            }
-
-            if (properMsg.Value.ExecuteMessage.UpdateConfig != null)
-            {
-                _logger.LogDebug("Contract config update, ignore");
-                continue;
-            }
-
-            if (properMsg.Value.ExecuteMessage.Transfer != null)
-            {
-                _logger.LogDebug("Contact COL-4 transfer, ignore");
-                continue;
-            }
-
-            if (properMsg.Value.ExecuteMessage.Send != null)
-            {
-                if (!properMsg.Value.ExecuteMessage.Send.Contract.EqualsIgnoreCase(TerraStakingContracts
-                        .MINE_STAKING_CONTRACT))
-                {
-                    _logger.LogDebug("Send to contract that is not MINE governance, skipping ");
-                    continue;
-                }
-
-
-                amount = Convert.ToDecimal(properMsg.Value.ExecuteMessage.Send.Amount) / 1_000_000m;
-            }
-            // SPEC farm does funky stuff
-            else if (properMsg.Value.ExecuteMessage.Withdraw != null)
-            {
-                _logger.LogDebug("Spec farm withdraw, skip");
-                continue;
-                var contractAddresses = TxLogExtensions.QueryTxLogsForAttributes(tx.Logs, "from_contract",
-                        attribute => StringExtensions.EqualsIgnoreCase(attribute.Key, "contract_address"))
-                    .ToList();
-
-                if (contractAddresses.Any(attribute =>
-                        attribute.Value.EqualsIgnoreCase(TerraStakingContracts.SPEC_PYLON_FARM)))
-                {
-                    if (contractAddresses.Any(attribute =>
-                            attribute.Value.EqualsIgnoreCase(TerraStakingContracts.MINE_STAKING_CONTRACT)))
-                    {
-                        var farmAmount =
-                            TxLogExtensions.QueryTxLogsForAttributeFirstOrDefault(tx.Logs, "from_contract",
-                                "farm_amount");
-                        amount = farmAmount.Value.ToInt64() / 1_000_000m;
-                    }
-                }
-            }
-            // SPEC compounding provides tokens for the MINE governance contract
-            else if (properMsg.Value.ExecuteMessage.Compound != null)
-            {
-                _logger.LogDebug("Spec farm compound, skip");
-                continue;
-                var contractAddresses = TxLogExtensions.QueryTxLogsForAttributes(tx.Logs, "from_contract",
-                        attribute => StringExtensions.EqualsIgnoreCase(attribute.Key, "contract_address"))
-                    .ToList();
-
-                if (contractAddresses.Any(attribute =>
-                        attribute.Value.EqualsIgnoreCase(TerraStakingContracts.SPEC_PYLON_FARM)))
-                {
-                    if (contractAddresses.Any(attribute =>
-                            attribute.Value.EqualsIgnoreCase(TerraStakingContracts.MINE_STAKING_CONTRACT)))
-                    {
-                        var stakeAmount =
-                            TxLogExtensions.QueryTxLogsForAttributeFirstOrDefault(tx.Logs, "from_contract",
-                                "stake_amount");
-                        amount = stakeAmount.Value.ToInt64() / 1_000_000m;
-                    }
-                }
-            }
-            else if (properMsg.Value.ExecuteMessage.Airdrop?.Claim != null)
-            {
-                _logger.LogDebug("Airdrop claim, skipping");
-                continue;
-            }
-            else if (properMsg.Value.ExecuteMessage.WithdrawVotingTokens != null)
-            {
-                amount = -1 *
-                         (Convert.ToDecimal(properMsg.Value.ExecuteMessage.WithdrawVotingTokens
-                             .Amount) / 1_000_000m);
-            }
-            else if (properMsg.Value.ExecuteMessage.Staking?.Unstake != null)
-            {
-                amount = -1 * properMsg.Value.ExecuteMessage.Staking.Unstake.Amount.ToInt64() / 1_000_000m;
-            }
-
-            else
-            {
-                _logger.LogWarning(
-                    "Transaction w. id {Id} and hash {TxHash} does not have send nor withdraw amount",
+                    "Transaction with id {TxId} and hash {TxHash} already exists, aborting",
                     tx.Id,
                     tx.TransactionHash
                 );
-                // throw new NotImplementedException("Cannot handle this TX for some reason");
-                continue;
+                return;
             }
 
-            var data = new TerraMineStakingEntity
-            {
-                Id = _idGenerator.Snowflake(),
-                TransactionId = tx.Id,
-                CreatedAt = tx.CreatedAt.UtcDateTime,
-                Sender = properMsg.Value.Sender,
-                Amount = amount,
-                TxHash = tx.TransactionHash,
-                IsBuyBack = false,
-            };
-            await dbTx.Connection.SaveAsync(data, token: stoppingToken);
+            await db.SaveAsync(obj: new TerraRawTransactionEntity
+                {
+                    Id = tx.Id,
+                    CreatedAt = tx.CreatedAt,
+                    TxHash = tx.TransactionHash,
+                    RawTx = JsonSerializer.Serialize(tx),
+                },
+                token: stoppingToken
+            );
+
+            await _bus.Publish(new MineStakingTransactionMessage
+                {
+                    TransactionId = tx.Id
+                },
+                stoppingToken
+            );
         }
 
-        dbTx.Commit();
-        return false;
+        _logger.LogInformation("Done inserting transactions");
     }
 }

--- a/src/Infrastructure/Hosting/TerraDataFetchers/PylonPoolsDataFetcher.cs
+++ b/src/Infrastructure/Hosting/TerraDataFetchers/PylonPoolsDataFetcher.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using NewRelic.Api.Agent;
 using Pylonboard.Infrastructure.Hosting.TerraDataFetchers.Internal.PylonPools;
 using Pylonboard.Kernel.DAL.Entities.Terra;
+using TerraDotnet;
 
 namespace Pylonboard.Infrastructure.Hosting.TerraDataFetchers;
 

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="MassTransit" Version="7.3.1" />
     <PackageReference Include="NewRelic.Agent.Api" Version="9.5.1" />
     <PackageReference Include="RapidCore" Version="0.27.2" />
+    <PackageReference Include="ServiceStack.Text" Version="6.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Kernel/Contracts/Terra/MineStakingTransactionMessage.cs
+++ b/src/Kernel/Contracts/Terra/MineStakingTransactionMessage.cs
@@ -1,0 +1,6 @@
+namespace Pylonboard.Kernel.Contracts.Terra;
+
+public record MineStakingTransactionMessage
+{
+    public long TransactionId { get; set; }
+}

--- a/src/ServiceHost/ServiceCollectionExtensions/MessageBusServiceExtensions.cs
+++ b/src/ServiceHost/ServiceCollectionExtensions/MessageBusServiceExtensions.cs
@@ -2,6 +2,7 @@ using MassTransit;
 using Pylonboard.Infrastructure.Hosting.TerraDataFetchers;
 using Pylonboard.Kernel.Config;
 using Pylonboard.ServiceHost.Config;
+using TerraDotnet;
 
 namespace Pylonboard.ServiceHost.ServiceCollectionExtensions;
 

--- a/src/ServiceHost/ServiceCollectionExtensions/MessageBusServiceExtensions.cs
+++ b/src/ServiceHost/ServiceCollectionExtensions/MessageBusServiceExtensions.cs
@@ -1,4 +1,5 @@
 using MassTransit;
+using Pylonboard.Infrastructure.Consumers.Terra;
 using Pylonboard.Infrastructure.Hosting.TerraDataFetchers;
 using Pylonboard.Kernel.Config;
 using Pylonboard.ServiceHost.Config;
@@ -29,7 +30,7 @@ public static class MessageBusServiceExtensions
             if (enabledServiceRolesConfig.IsRoleEnabled(ServiceRoles.BACKGROUND_WORKER))
             {
                 x.AddConsumers(
-                    typeof(TerraAirdropContracts).Assembly
+                    typeof(MineStakingTransactionConsumer).Assembly
                 );
             }
                 

--- a/src/TerraDotnet/TerraStakingContracts.cs
+++ b/src/TerraDotnet/TerraStakingContracts.cs
@@ -1,4 +1,4 @@
-namespace Pylonboard.Infrastructure.Hosting.TerraDataFetchers;
+namespace TerraDotnet;
 
 public static class TerraStakingContracts
 {

--- a/test/NarrowIntegrationTests/Oracles/TerraLcdClient/TerraMoneyFcdApiClientTests.cs
+++ b/test/NarrowIntegrationTests/Oracles/TerraLcdClient/TerraMoneyFcdApiClientTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Pylonboard.Infrastructure.Hosting.TerraDataFetchers;
 using Refit;
+using TerraDotnet;
 using TerraDotnet.TerraFcd;
 using Xunit;
 using Xunit.Abstractions;

--- a/test/NarrowIntegrationTests/Oracles/TerraLcdClient/TerraMoneyLcdApiClientTests.cs
+++ b/test/NarrowIntegrationTests/Oracles/TerraLcdClient/TerraMoneyLcdApiClientTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Pylonboard.Infrastructure.Hosting.TerraDataFetchers;
 using Refit;
+using TerraDotnet;
 using TerraDotnet.TerraLcd;
 using TerraDotnet.TerraLcd.Messages;
 using Xunit;

--- a/test/UnitTests/Infrastructure/Consumers/Terra/MineStakingTransactionConsumerTests.cs
+++ b/test/UnitTests/Infrastructure/Consumers/Terra/MineStakingTransactionConsumerTests.cs
@@ -1,0 +1,100 @@
+using System.IO;
+using System.Linq;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Pylonboard.Infrastructure.Consumers.Terra;
+using Pylonboard.Kernel.IdGeneration;
+using ServiceStack.Data;
+using TerraDotnet.Extensions;
+using TerraDotnet.TerraFcd;
+using TerraDotnet.TerraFcd.Messages;
+using Xunit;
+
+namespace UnitTests.Infrastructure.Consumers.Terra;
+
+public class MineStakingTransactionConsumerTests
+{
+    private readonly IdGenerator _idGenerator;
+    private readonly MineStakingTransactionConsumer _consumer;
+    private readonly string _testFilesBasePath;
+
+    public MineStakingTransactionConsumerTests()
+    {
+        _idGenerator = A.Fake<IdGenerator>(opts => opts.Strict());
+        _consumer = new MineStakingTransactionConsumer(
+            A.Fake<ILogger<MineStakingTransactionConsumer>>(),
+            A.Fake<IDbConnectionFactory>(opts => opts.Strict()),
+            _idGenerator
+        );
+        _testFilesBasePath = "./Infrastructure/Consumers/Terra/TestFiles";
+    }
+
+    [Fact]
+    public void HandleGovStake_works()
+    {
+        // Arrange
+        A.CallTo(() => _idGenerator.Snowflake()).Returns(1);
+        var json = File.ReadAllText($"{_testFilesBasePath}/mine_gov_stake.json");
+        var terraTx = json.ToObject<TerraTxWrapper>()!;
+        var coreTx = TerraTransactionValueFactory.GetIt(terraTx);
+
+        // Act
+        var actuals = _consumer.ProcessTransaction(
+            terraTx,
+            coreTx
+        );
+
+        // Assert
+        Assert.Single(actuals);
+        var actual = actuals.Single();
+
+        Assert.Equal(1, actual.Id);
+        Assert.Equal(3984.27m, actual.Amount);
+        Assert.Equal("terra16hw950c7gznakfe5rcuj4dj8v94em9kdw9wak6", actual.Sender);
+        Assert.Equal(false, actual.IsBuyBack);
+    }
+
+    [Fact]
+    public void HandleGovUnstake_works()
+    {
+        // Arrange
+        A.CallTo(() => _idGenerator.Snowflake()).Returns(1);
+        var json = File.ReadAllText($"{_testFilesBasePath}/mine_gov_unstake.json");
+        var terraTx = json.ToObject<TerraTxWrapper>()!;
+        var coreTx = TerraTransactionValueFactory.GetIt(terraTx);
+
+        // Act
+        var actuals = _consumer.ProcessTransaction(
+            terraTx,
+            coreTx
+        );
+
+        // Assert
+        Assert.Single(actuals);
+        var actual = actuals.Single();
+
+        Assert.Equal(1, actual.Id);
+        Assert.Equal(-18000m, actual.Amount);
+        Assert.Equal("terra1g0uzl468etgkx0gkts42mg7ly6waqkemw89lsh", actual.Sender);
+        Assert.Equal(false, actual.IsBuyBack);
+    }
+
+    [Fact]
+    public void IgnoresVotes()
+    {
+        // Arrange
+        A.CallTo(() => _idGenerator.Snowflake()).Returns(1);
+        var json = File.ReadAllText($"{_testFilesBasePath}/mine_gov_vote.json");
+        var terraTx = json.ToObject<TerraTxWrapper>()!;
+        var coreTx = TerraTransactionValueFactory.GetIt(terraTx);
+
+        // Act
+        var actuals = _consumer.ProcessTransaction(
+            terraTx,
+            coreTx
+        );
+
+        // Assert
+        Assert.Empty(actuals);
+    }
+}

--- a/test/UnitTests/Infrastructure/Consumers/Terra/TestFiles/mine_gov_stake.json
+++ b/test/UnitTests/Infrastructure/Consumers/Terra/TestFiles/mine_gov_stake.json
@@ -1,0 +1,250 @@
+{
+  "Id": 230714291,
+  "Tx": {
+    "Type": "core/StdTx",
+    "Value": {
+      "fee": {
+        "gas": "712521",
+        "amount": [
+          {
+            "denom": "uusd",
+            "amount": "106879"
+          }
+        ]
+      },
+      "msg": [
+        {
+          "type": "wasm/MsgExecuteContract",
+          "value": {
+            "coins": [],
+            "sender": "terra16hw950c7gznakfe5rcuj4dj8v94em9kdw9wak6",
+            "contract": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy",
+            "execute_msg": {
+              "send": {
+                "msg": "eyJzdGFrZSI6e319",
+                "amount": "3984270000",
+                "contract": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+              }
+            }
+          }
+        }
+      ],
+      "memo": "",
+      "signatures": [
+        {
+          "pub_key": {
+            "type": "tendermint/PubKeySecp256k1",
+            "value": "At9NUQqdpKlt58qxinx8HZw2AXs2xsN5WNNEv6L8Nxko"
+          },
+          "signature": "M87dXEwWedxoDjdv/Ha0bj4Nhpc1EyuLkpD9plCLemcFAoYxRy7i8CagqW2r3aHWEJvKRcEI7Sfbs95QRN6JMw=="
+        }
+      ],
+      "timeout_height": "0"
+    }
+  },
+  "code": 0,
+  "logs": [
+    {
+      "events": [
+        {
+          "type": "execute_contract",
+          "attributes": [
+            {
+              "key": "sender",
+              "value": "terra16hw950c7gznakfe5rcuj4dj8v94em9kdw9wak6"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+            },
+            {
+              "key": "sender",
+              "value": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "sender",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "sender",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            }
+          ]
+        },
+        {
+          "type": "from_contract",
+          "attributes": [
+            {
+              "key": "contract_address",
+              "value": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+            },
+            {
+              "key": "action",
+              "value": "send"
+            },
+            {
+              "key": "from",
+              "value": "terra16hw950c7gznakfe5rcuj4dj8v94em9kdw9wak6"
+            },
+            {
+              "key": "to",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "amount",
+              "value": "3984270000"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "airdrop_update"
+            },
+            {
+              "key": "updated",
+              "value": "[0, 1, 2, 3]"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "staking"
+            },
+            {
+              "key": "sender",
+              "value": "terra16hw950c7gznakfe5rcuj4dj8v94em9kdw9wak6"
+            },
+            {
+              "key": "share",
+              "value": "3665508536"
+            },
+            {
+              "key": "amount",
+              "value": "3984270000"
+            }
+          ]
+        },
+        {
+          "type": "message",
+          "attributes": [
+            {
+              "key": "action",
+              "value": "/terra.wasm.v1beta1.MsgExecuteContract"
+            },
+            {
+              "key": "module",
+              "value": "wasm"
+            },
+            {
+              "key": "sender",
+              "value": "terra16hw950c7gznakfe5rcuj4dj8v94em9kdw9wak6"
+            },
+            {
+              "key": "module",
+              "value": "wasm"
+            },
+            {
+              "key": "sender",
+              "value": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+            },
+            {
+              "key": "module",
+              "value": "wasm"
+            },
+            {
+              "key": "sender",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "module",
+              "value": "wasm"
+            },
+            {
+              "key": "sender",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            }
+          ]
+        },
+        {
+          "type": "wasm",
+          "attributes": [
+            {
+              "key": "contract_address",
+              "value": "terra1kcthelkax4j9x8d3ny6sdag0qmxxynl3qtcrpy"
+            },
+            {
+              "key": "action",
+              "value": "send"
+            },
+            {
+              "key": "from",
+              "value": "terra16hw950c7gznakfe5rcuj4dj8v94em9kdw9wak6"
+            },
+            {
+              "key": "to",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "amount",
+              "value": "3984270000"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "airdrop_update"
+            },
+            {
+              "key": "updated",
+              "value": "[0, 1, 2, 3]"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "staking"
+            },
+            {
+              "key": "sender",
+              "value": "terra16hw950c7gznakfe5rcuj4dj8v94em9kdw9wak6"
+            },
+            {
+              "key": "share",
+              "value": "3665508536"
+            },
+            {
+              "key": "amount",
+              "value": "3984270000"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "height": "6594684",
+  "txhash": "D94D6B44CF837AA4FE93396323D86187C14BED6467A84B408C85191539494B25",
+  "ChainId": "columbus-5",
+  "gas_used": "417734",
+  "timestamp": "2022-02-23T09:58:25+00:00",
+  "gas_wanted": "712521"
+}

--- a/test/UnitTests/Infrastructure/Consumers/Terra/TestFiles/mine_gov_unstake.json
+++ b/test/UnitTests/Infrastructure/Consumers/Terra/TestFiles/mine_gov_unstake.json
@@ -1,0 +1,186 @@
+{
+  "Id": 230589299,
+  "Tx": {
+    "Type": "core/StdTx",
+    "Value": {
+      "fee": {
+        "gas": "612643",
+        "amount": [
+          {
+            "denom": "uusd",
+            "amount": "91897"
+          }
+        ]
+      },
+      "msg": [
+        {
+          "type": "wasm/MsgExecuteContract",
+          "value": {
+            "coins": [],
+            "sender": "terra1g0uzl468etgkx0gkts42mg7ly6waqkemw89lsh",
+            "contract": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp",
+            "execute_msg": {
+              "staking": {
+                "unstake": {
+                  "amount": "18000000000"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "memo": "",
+      "signatures": [
+        {
+          "pub_key": {
+            "type": "tendermint/PubKeySecp256k1",
+            "value": "A/0g36vaZLGLmzXA+u/ZhqoIE1etOxaZw+6ECt/d/08P"
+          },
+          "signature": "vOasTGG0w2k5B2IBuO2LOo2ILlpJjL6EkPiFC1yNjXYP3Fn626V7y1l6vAI7eZwKZOcXV6VzA6jw31WcjvVzCQ=="
+        }
+      ],
+      "timeout_height": "0"
+    }
+  },
+  "code": 0,
+  "logs": [
+    {
+      "events": [
+        {
+          "type": "execute_contract",
+          "attributes": [
+            {
+              "key": "sender",
+              "value": "terra1g0uzl468etgkx0gkts42mg7ly6waqkemw89lsh"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "sender",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "sender",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            }
+          ]
+        },
+        {
+          "type": "from_contract",
+          "attributes": [
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "airdrop_update"
+            },
+            {
+              "key": "updated",
+              "value": "[0, 1, 2, 3]"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "withdraw"
+            },
+            {
+              "key": "amount",
+              "value": "18000000000"
+            },
+            {
+              "key": "claim_id",
+              "value": "0"
+            }
+          ]
+        },
+        {
+          "type": "message",
+          "attributes": [
+            {
+              "key": "action",
+              "value": "/terra.wasm.v1beta1.MsgExecuteContract"
+            },
+            {
+              "key": "module",
+              "value": "wasm"
+            },
+            {
+              "key": "sender",
+              "value": "terra1g0uzl468etgkx0gkts42mg7ly6waqkemw89lsh"
+            },
+            {
+              "key": "module",
+              "value": "wasm"
+            },
+            {
+              "key": "sender",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "module",
+              "value": "wasm"
+            },
+            {
+              "key": "sender",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            }
+          ]
+        },
+        {
+          "type": "wasm",
+          "attributes": [
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "airdrop_update"
+            },
+            {
+              "key": "updated",
+              "value": "[0, 1, 2, 3]"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "withdraw"
+            },
+            {
+              "key": "amount",
+              "value": "18000000000"
+            },
+            {
+              "key": "claim_id",
+              "value": "0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "height": "6591694",
+  "txhash": "087C2BE71FBC175EAF45EB3B8E8367A5773B1F03166A990456146AF027F44FAE",
+  "ChainId": "columbus-5",
+  "gas_used": "360453",
+  "timestamp": "2022-02-23T04:29:26+00:00",
+  "gas_wanted": "612643"
+}

--- a/test/UnitTests/Infrastructure/Consumers/Terra/TestFiles/mine_gov_vote.json
+++ b/test/UnitTests/Infrastructure/Consumers/Terra/TestFiles/mine_gov_vote.json
@@ -1,0 +1,149 @@
+{
+  "Id": 221941412,
+  "Tx": {
+    "Type": "core/StdTx",
+    "Value": {
+      "fee": {
+        "gas": "329161",
+        "amount": [
+          {
+            "denom": "uusd",
+            "amount": "49375"
+          }
+        ]
+      },
+      "msg": [
+        {
+          "type": "wasm/MsgExecuteContract",
+          "value": {
+            "coins": [],
+            "sender": "terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9",
+            "contract": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp",
+            "execute_msg": {
+              "poll": {
+                "cast_vote": {
+                  "vote": "yes",
+                  "amount": "9597000000",
+                  "poll_id": 17
+                }
+              }
+            }
+          }
+        }
+      ],
+      "memo": "",
+      "signatures": [
+        {
+          "pub_key": {
+            "type": "tendermint/PubKeySecp256k1",
+            "value": "AySzYmTTja9sOkpvkQvReVjWQVMErect0yEqVx8DqM41"
+          },
+          "signature": "daDt1m3zVYW/HRM4KHV/85nGuHzzIdEL49rXsnuFHLYfEaFbzxL+RSUwRBlxwsf/ZCbtLbf04O9kJfGpxcoP8g=="
+        }
+      ],
+      "timeout_height": "0"
+    }
+  },
+  "code": 0,
+  "logs": [
+    {
+      "events": [
+        {
+          "type": "execute_contract",
+          "attributes": [
+            {
+              "key": "sender",
+              "value": "terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9"
+            },
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            }
+          ]
+        },
+        {
+          "type": "from_contract",
+          "attributes": [
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "cast_vote"
+            },
+            {
+              "key": "poll_id",
+              "value": "17"
+            },
+            {
+              "key": "amount",
+              "value": "9597000000"
+            },
+            {
+              "key": "voter",
+              "value": "terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9"
+            },
+            {
+              "key": "vote_option",
+              "value": "yes"
+            }
+          ]
+        },
+        {
+          "type": "message",
+          "attributes": [
+            {
+              "key": "action",
+              "value": "/terra.wasm.v1beta1.MsgExecuteContract"
+            },
+            {
+              "key": "module",
+              "value": "wasm"
+            },
+            {
+              "key": "sender",
+              "value": "terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9"
+            }
+          ]
+        },
+        {
+          "type": "wasm",
+          "attributes": [
+            {
+              "key": "contract_address",
+              "value": "terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp"
+            },
+            {
+              "key": "action",
+              "value": "cast_vote"
+            },
+            {
+              "key": "poll_id",
+              "value": "17"
+            },
+            {
+              "key": "amount",
+              "value": "9597000000"
+            },
+            {
+              "key": "voter",
+              "value": "terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9"
+            },
+            {
+              "key": "vote_option",
+              "value": "yes"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "height": "6377395",
+  "txhash": "93C90E06DA877E5CA109702EEDA3AAF22B556B52D9F35505CCA9CAC977F8B5C3",
+  "ChainId": "columbus-5",
+  "raw_log": "[{\"events\":[{\"type\":\"execute_contract\",\"attributes\":[{\"key\":\"sender\",\"value\":\"terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9\"},{\"key\":\"contract_address\",\"value\":\"terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp\"}]},{\"type\":\"from_contract\",\"attributes\":[{\"key\":\"contract_address\",\"value\":\"terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp\"},{\"key\":\"action\",\"value\":\"cast_vote\"},{\"key\":\"poll_id\",\"value\":\"17\"},{\"key\":\"amount\",\"value\":\"9597000000\"},{\"key\":\"voter\",\"value\":\"terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9\"},{\"key\":\"vote_option\",\"value\":\"yes\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/terra.wasm.v1beta1.MsgExecuteContract\"},{\"key\":\"module\",\"value\":\"wasm\"},{\"key\":\"sender\",\"value\":\"terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9\"}]},{\"type\":\"wasm\",\"attributes\":[{\"key\":\"contract_address\",\"value\":\"terra1xu8utj38xuw6mjwck4n97enmavlv852zkcvhgp\"},{\"key\":\"action\",\"value\":\"cast_vote\"},{\"key\":\"poll_id\",\"value\":\"17\"},{\"key\":\"amount\",\"value\":\"9597000000\"},{\"key\":\"voter\",\"value\":\"terra1nmarayrnwvl885qkjfjyn5ssf4vxaswjc9mvy9\"},{\"key\":\"vote_option\",\"value\":\"yes\"}]}]}]",
+  "gas_used": "198473",
+  "timestamp": "2022-02-06T19:28:23+00:00",
+  "gas_wanted": "329161"
+}

--- a/test/UnitTests/UnitTests.csproj
+++ b/test/UnitTests/UnitTests.csproj
@@ -50,6 +50,18 @@
     <Content Include="Infrastructure\Consumers\Terra\TestFiles\bpsi_route_swap_to_ust.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <None Remove="Infrastructure\Consumers\Terra\TestFiles\mine_gov_stake.json" />
+    <Content Include="Infrastructure\Consumers\Terra\TestFiles\mine_gov_stake.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <None Remove="Infrastructure\Consumers\Terra\TestFiles\mine_gov_unstake.json" />
+    <Content Include="Infrastructure\Consumers\Terra\TestFiles\mine_gov_unstake.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <None Remove="Infrastructure\Consumers\Terra\TestFiles\mine_gov_vote.json" />
+    <Content Include="Infrastructure\Consumers\Terra\TestFiles\mine_gov_vote.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR rewrites the MINE governance staking fetcher / consumption into a MT consumer.

Though migrations once merged to master are "don't touch" I had to slightly rewrite one since I broke the mine fetcher contract. Should be a NO-OP as this migration has applied in prod some time ago.