### PR TITLE
PB-44: use distributed locks during various sync jobs

### DIFF
--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="DistributedLock.Postgres" Version="1.0.2" />
     <PackageReference Include="MassTransit" Version="7.3.1" />
     <PackageReference Include="NewRelic.Agent.Api" Version="9.5.1" />
     <PackageReference Include="RapidCore" Version="0.27.2" />

--- a/src/ServiceHost/ServiceCollectionExtensions/BackgroundJobServiceCollectionExtension.cs
+++ b/src/ServiceHost/ServiceCollectionExtensions/BackgroundJobServiceCollectionExtension.cs
@@ -1,6 +1,10 @@
 using Hangfire;
 using Hangfire.InMemory;
+using Medallion.Threading;
+using Medallion.Threading.Postgres;
 using Pylonboard.Infrastructure.Oracles.ExchangeRates.Terra;
+using Pylonboard.Kernel.Config;
+using Pylonboard.ServiceHost.Config;
 using Pylonboard.ServiceHost.RecurringJobs;
 
 namespace Pylonboard.ServiceHost.ServiceCollectionExtensions;
@@ -23,7 +27,7 @@ public static class BackgroundJobServiceCollectionExtension
 
         // Add the processing server as IHostedService
         services.AddHangfireServer();
-        
+
         // Add our jobs
         services.AddTransient<TerraExchangeRateOracle>();
         services.AddTransient<TerraMoneyRefreshJob>();
@@ -34,6 +38,11 @@ public static class BackgroundJobServiceCollectionExtension
 
         services.AddTransient<CronjobManager>();
         services.AddTransient<RecurringJobManager>();
+
+        services.AddSingleton<IDistributedLockProvider>(_ =>
+            new PostgresDistributedSynchronizationProvider((new PylonboardConfig(configuration) as IDbConfig)
+                .ConnectionString));
+
         return services;
     }
 }


### PR DESCRIPTION
In order to ensure that they don't execute concurrently