### PR TITLE
feat: add "my pylon stake" query

### DIFF
--- a/src/ServiceHost/Endpoints/MyPylonStake/MyPylonStakeGraph.cs
+++ b/src/ServiceHost/Endpoints/MyPylonStake/MyPylonStakeGraph.cs
@@ -1,0 +1,6 @@
+namespace Pylonboard.ServiceHost.Endpoints;
+
+public record MyPylonStakeGraph
+{
+    public decimal Amount { get; set; }
+}

--- a/src/ServiceHost/Endpoints/MyPylonStake/MyPylonStakeService.cs
+++ b/src/ServiceHost/Endpoints/MyPylonStake/MyPylonStakeService.cs
@@ -1,0 +1,40 @@
+using NewRelic.Api.Agent;
+using Pylonboard.Kernel.DAL.Entities.Terra.Views;
+using ServiceStack.Data;
+using ServiceStack.OrmLite;
+
+namespace Pylonboard.ServiceHost.Endpoints.MyPylonStake;
+
+public class MyPylonStakeService
+{
+    private readonly ILogger<MyPylonStakeService> _logger;
+    private readonly IDbConnectionFactory _dbConnectionFactory;
+
+    public MyPylonStakeService(
+        ILogger<MyPylonStakeService> logger,
+        IDbConnectionFactory dbConnectionFactory
+    )
+    {
+        _logger = logger;
+        _dbConnectionFactory = dbConnectionFactory;
+    }
+
+    [Trace]
+    public async Task<MyPylonStakeGraph?> GetMyPylonStakeAsync(string terraWallet, CancellationToken cancellationToken)
+    {
+        using var db = await _dbConnectionFactory.OpenDbConnectionAsync(token: cancellationToken);
+
+        var staked = await db.SingleAsync<decimal>(
+            db.From<MineWalletStakeView>()
+                .Where(q => q.Wallet == terraWallet)
+                .Select(q => new
+                {
+                    Amount = q.Sum
+                }), token: cancellationToken);
+
+        return new MyPylonStakeGraph
+        {
+            Amount = staked
+        };
+    }
+}

--- a/src/ServiceHost/Endpoints/Query.cs
+++ b/src/ServiceHost/Endpoints/Query.cs
@@ -10,6 +10,7 @@ using Pylonboard.ServiceHost.Endpoints.MineStakingStats;
 using Pylonboard.ServiceHost.Endpoints.MineTreasury;
 using Pylonboard.ServiceHost.Endpoints.MineWalletStats;
 using Pylonboard.ServiceHost.Endpoints.MyGatewayPools;
+using Pylonboard.ServiceHost.Endpoints.MyPylonStake;
 using Pylonboard.ServiceHost.Endpoints.Types;
 using ServiceStack.Caching;
 
@@ -280,7 +281,27 @@ public class Query
         if (data == default)
         {
             data = await service.GetGatewayPoolDetailsAsync(terraWallet, poolContractId, cancellationToken);
-            cacheClient.Set(cacheKey, data);
+            cacheClient.Set(cacheKey, data, TimeSpan.FromMinutes(60));
+        }
+
+        return data;
+    }
+
+    [Trace]
+    public async Task<MyPylonStakeGraph> GetMyPylonStake(
+        string terraWallet,
+        [Service] MyPylonStakeService service,
+        [Service] ICacheClient cacheClient,
+        CancellationToken cancellationToken
+    )
+    {
+        var cacheKey = $"cache:pylon-stake:{terraWallet}";
+        var data = cacheClient.Get<MyPylonStakeGraph>(cacheKey);
+
+        if (data == default)
+        {
+            data = await service.GetMyPylonStakeAsync(terraWallet, cancellationToken);
+            cacheClient.Set(cacheKey, data, TimeSpan.FromMinutes(30));
         }
 
         return data;

--- a/src/ServiceHost/ServiceCollectionExtensions/EndpointsServiceCollectionExtensions.cs
+++ b/src/ServiceHost/ServiceCollectionExtensions/EndpointsServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Pylonboard.ServiceHost.Endpoints.MineStakingStats;
 using Pylonboard.ServiceHost.Endpoints.MineTreasury;
 using Pylonboard.ServiceHost.Endpoints.MineWalletStats;
 using Pylonboard.ServiceHost.Endpoints.MyGatewayPools;
+using Pylonboard.ServiceHost.Endpoints.MyPylonStake;
 using ServiceStack.Caching;
 
 namespace Pylonboard.ServiceHost.ServiceCollectionExtensions;
@@ -23,6 +24,7 @@ public static class EndpointsServiceCollectionExtensions
         services.AddTransient<ArbitrageService>();
         services.AddTransient<MyGatewayPoolService>();
         services.AddTransient<FxRatesService>();
+        services.AddTransient<MyPylonStakeService>();
 
         services.AddSingleton<ICacheClient>(c => new MemoryCacheClient());
 


### PR DESCRIPTION
Add support for querying "my pylon stake" .

Based off blockchain txes and estimated buy-backs, rather than contract queries towards Pylon.