### PR TITLE
chore(helm): define startup probes w. long timeout

### DIFF
--- a/charts/pylonboard/templates/deployment.yaml
+++ b/charts/pylonboard/templates/deployment.yaml
@@ -49,10 +49,14 @@ spec:
             httpGet:
               path: /health
               port: http
-          readinessProbe:
+            failureThreshold: 1
+            periodSeconds: 10
+          startupProbe:
             httpGet:
               path: /health
               port: http
+            failureThreshold: 90
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}


### PR DESCRIPTION
To account for slow running migrations.